### PR TITLE
replace for loop for counting duplicates

### DIFF
--- a/Python/rdrobust/src/rdrobust/funs.py
+++ b/Python/rdrobust/src/rdrobust/funs.py
@@ -498,4 +498,8 @@ def rdrobust_bw (Y, X, T, Z, C, W, c, o, nu, o_B, h_V, h_B, scale,
     
     return V, B, R, rate;
 
+def num_duplicates(x):
+    x = x.reshape(-1)
+    vals, counts = np.unique(x, return_counts=True)
+    return counts[np.searchsorted(vals, x)];
 

--- a/Python/rdrobust/src/rdrobust/rdbwselect.py
+++ b/Python/rdrobust/src/rdrobust/rdbwselect.py
@@ -374,8 +374,8 @@ def rdbwselect(y, x, c = None, fuzzy = None, deriv = None, p = None, q = None,
     dups_r = np.zeros(N_r).astype(int)
     dupsid_r = np.zeros(N_r).astype(int)
     if vce == "nn":
-        for i in range(N_l): dups_l[i]=sum(X_l==X_l[i])
-        for i in range(N_r): dups_r[i]=sum(X_r==X_r[i])
+        dups_l = num_duplicates(X_l)
+        dups_r = num_duplicates(X_r)
         i = 0
         while i < N_l:
             dupsid_l[i:int(i+dups_l[i])] = np.arange(1,int(dups_l[i]+1))

--- a/Python/rdrobust/src/rdrobust/rdrobust.py
+++ b/Python/rdrobust/src/rdrobust/rdrobust.py
@@ -476,8 +476,8 @@ def rdrobust(y, x, c = None, fuzzy = None, deriv = None,
     edups_r = np.zeros(eN_r).astype(int)
     edupsid_r = np.zeros(eN_r).astype(int)
     if vce=="nn":
-        for i in range(eN_l): edups_l[i] = sum(eX_l==eX_l[i])
-        for i in range(eN_r): edups_r[i] = sum(eX_r==eX_r[i])
+        edups_l = num_duplicates(eX_l)
+        edups_r = num_duplicates(eX_r)
         i = 0
         while i < eN_l:
             edupsid_l[i:(i+edups_l[i])] = np.arange(1,edups_l[i]+1)


### PR DESCRIPTION
Thank you for the great package!

For larger datasets checking for repeated observations can be costly (default `nn` covariance estimator). Replacing the for loop with a simple function could help with performance. The change would essentially be:


![duplicate_count_test](https://user-images.githubusercontent.com/14111589/164587300-874feee3-e422-414a-afb0-d3d61960575c.png)

