### PR TITLE
Update setup.cfg

### DIFF
--- a/Python/rdrobust/setup.cfg
+++ b/Python/rdrobust/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     numpy
     pandas
     scipy
-    sklearn
+    scikit-learn
     plotnine
 
 [options.packages.find]


### PR DESCRIPTION
``sklearn`` is deprecated and needs to be replaced with ``scikit-learn``, otherwise ``pip install rdrobust`` fails. 

```bash
pip install rdrobust
Collecting rdrobust
  Downloading rdrobust-1.0.8-py3-none-any.whl (30 kB)
Requirement already satisfied: plotnine in ./anaconda3/envs/GeoPython39env/lib/python3.9/site-packages (from rdrobust) (0.0.0)
Requirement already satisfied: pandas in ./anaconda3/envs/GeoPython39env/lib/python3.9/site-packages (from rdrobust) (1.5.3)
Requirement already satisfied: scipy in ./anaconda3/envs/GeoPython39env/lib/python3.9/site-packages (from rdrobust) (1.10.0)
Collecting sklearn
  Downloading sklearn-0.0.post1.tar.gz (3.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.

      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error

      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package

      If the previous advice does not cover your use case, feel free to report it at
      https://github.com/scikit-learn/sklearn-pypi-package/issues/new
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```