### PR TITLE
Fix read-only error in `rdplot` for `numpy>=2.0`

### DIFF
--- a/Python/rdrobust/src/rdrobust/rdbwselect.py
+++ b/Python/rdrobust/src/rdrobust/rdbwselect.py
@@ -16,187 +16,187 @@ def rdbwselect(y, x, c = None, fuzzy = None, deriv = None, p = None, q = None,
                scaleregul = 1, sharpbw = False, all = None, subset = None,
                masspoints = "adjust", bwcheck = None, bwrestrict = True,
                stdvars = False, prchk = True):
-        
-    
-    '''
+
+
+    r"""
      Implements bandwidth selectors for local polynomial Regression Discontinuity (RD) point estimators and inference procedures developed in Calonico, Cattaneo and Titiunik (2014a), Calonico, Cattaneo and Farrell (2018), Calonico, Cattaneo, Farrell and Titiunik (2019) and Calonico, Cattaneo and Farrell (2020).
-    
+
     Companion commands are: rdrobust for point estimation and inference procedures, and rdplot for data-driven RD plots (see Calonico, Cattaneo and Titiunik (2015a) for details).
-    
+
     A detailed introduction to this command is given in Calonico, Cattaneo and Titiunik (2015b) and Calonico, Cattaneo, Farrell and Titiunik (2019). A companion Stata package is described in Calonico, Cattaneo and Titiunik (2014b).
-    
+
     For more details, and related Stata and R packages useful for analysis of RD designs, visit https://rdpackages.github.io/
-    
-   
+
+
     Parameters
     ----------
-    y	
+    y
     is the dependent variable.
-    
-    x	
+
+    x
     is the running variable (a.k.a. score or forcing variable).
-    
-    c	
+
+    c
     specifies the RD cutoff in x; default is c = 0.
-    
-    fuzzy	
+
+    fuzzy
     specifies the treatment status variable used to implement fuzzy RD estimation (or Fuzzy Kink RD if deriv=1 is also specified). Default is Sharp RD design and hence this option is not used.
-    
-    deriv	
+
+    deriv
     specifies the order of the derivative of the regression functions to be estimated. Default is deriv=0 (for Sharp RD, or for Fuzzy RD if fuzzy is also specified). Setting deriv=1 results in estimation of a Kink RD design (up to scale), or Fuzzy Kink RD if fuzzy is also specified.
-    
-    p	
+
+    p
     specifies the order of the local-polynomial used to construct the point-estimator; default is p = 1 (local linear regression).
-    
-    q	
+
+    q
     specifies the order of the local-polynomial used to construct the bias-correction; default is q = 2 (local quadratic regression).
-    
-    covs	
+
+    covs
     specifies additional covariates to be used for estimation and inference.
-    
-    covs_drop	
+
+    covs_drop
     if TRUE, it checks for collinear additional covariates and drops them. Default is TRUE.
-    
-    kernel	
+
+    kernel
     is the kernel function used to construct the local-polynomial estimator(s). Options are triangular (default option), epanechnikov and uniform.
-    
-    weights	
+
+    weights
     is the variable used for optional weighting of the estimation procedure. The unit-specific weights multiply the kernel function.
-    
-    bwselect	
+
+    bwselect
     specifies the bandwidth selection procedure to be used. Options are:
-    
+
     mserd one common MSE-optimal bandwidth selector for the RD treatment effect estimator.
-    
+
     msetwo two different MSE-optimal bandwidth selectors (below and above the cutoff) for the RD treatment effect estimator.
-    
+
     msesum one common MSE-optimal bandwidth selector for the sum of regression estimates (as opposed to difference thereof).
-    
+
     msecomb1 for min(mserd,msesum).
-    
+
     msecomb2 for median(msetwo,mserd,msesum), for each side of the cutoff separately.
-    
+
     cerrd one common CER-optimal bandwidth selector for the RD treatment effect estimator.
-    
+
     certwo two different CER-optimal bandwidth selectors (below and above the cutoff) for the RD treatment effect estimator.
-    
+
     cersum one common CER-optimal bandwidth selector for the sum of regression estimates (as opposed to difference thereof).
-    
+
     cercomb1 for min(cerrd,cersum).
-    
+
     cercomb2 for median(certwo,cerrd,cersum), for each side of the cutoff separately.
-    
+
     Note: MSE = Mean Square Error; CER = Coverage Error Rate. Default is bwselect=mserd. For details on implementation see Calonico, Cattaneo and Titiunik (2014a), Calonico, Cattaneo and Farrell (2018), and Calonico, Cattaneo, Farrell and Titiunik (2017), and the companion software articles.
-    
-    vce	
+
+    vce
     specifies the procedure used to compute the variance-covariance matrix estimator. Options are:
-    
+
     nn for heteroskedasticity-robust nearest neighbor variance estimator with nnmatch the (minimum) number of neighbors to be used.
-    
+
     hc0 for heteroskedasticity-robust plug-in residuals variance estimator without weights.
-    
+
     hc1 for heteroskedasticity-robust plug-in residuals variance estimator with hc1 weights.
-    
+
     hc2 for heteroskedasticity-robust plug-in residuals variance estimator with hc2 weights.
-    
+
     hc3 for heteroskedasticity-robust plug-in residuals variance estimator with hc3 weights.
-    
+
     Default is vce=nn.
-    
-    cluster	
+
+    cluster
     indicates the cluster ID variable used for cluster-robust variance estimation with degrees-of-freedom weights. By default it is combined with vce=nn for cluster-robust nearest neighbor variance estimation. Another option is plug-in residuals combined with vce=hc0.
-    
-    nnmatch	
+
+    nnmatch
     to be combined with for vce=nn for heteroskedasticity-robust nearest neighbor variance estimator with nnmatch indicating the minimum number of neighbors to be used. Default is nnmatch=3
-    
-    scaleregul	
+
+    scaleregul
     specifies scaling factor for the regularization term added to the denominator of the bandwidth selectors. Setting scaleregul = 0 removes the regularization term from the bandwidth selectors; default is scaleregul = 1.
-    
-    sharpbw	
+
+    sharpbw
     option to perform fuzzy RD estimation using a bandwidth selection procedure for the sharp RD model. This option is automatically selected if there is perfect compliance at either side of the threshold.
-    
-    all	
+
+    all
     if specified, rdbwselect reports all available bandwidth selection procedures.
-    
-    subset	
+
+    subset
     an optional vector specifying a subset of observations to be used.
-    
-    masspoints	
+
+    masspoints
     checks and controls for repeated observations in the running variable. Options are:
-    
+
     (i) off: ignores the presence of mass points;
-    
+
     (ii) check: looks for and reports the number of unique observations at each side of the cutoff.
-    
+
     (iii) adjust: controls that the preliminary bandwidths used in the calculations contain a minimal number of unique observations. By default it uses 10 observations, but it can be manually adjusted with the option bwcheck).
-    
+
     Default option is masspoints=adjust.
-    
-    bwcheck	
+
+    bwcheck
     if a positive integer is provided, the preliminary bandwidth used in the calculations is enlarged so that at least bwcheck unique observations are used.
-    
-    bwrestrict	
+
+    bwrestrict
     if TRUE, computed bandwidths are restricted to lie within the range of x; default is bwrestrict = TRUE.
-    
-    stdvars	
+
+    stdvars
     if TRUE, x and y are standardized before computing the bandwidths; default is stdvars = FALSE.
-    
-    prchk	
+
+    prchk
     internal check function.
-    
+
     Returns
     -------
-    N	
+    N
     vector with sample sizes to the left and to the righst of the cutoff.
-    
-    c	
+
+    c
     cutoff value.
-    
-    p	
+
+    p
     order of the local-polynomial used to construct the point-estimator.
-    
-    q	
+
+    q
     order of the local-polynomial used to construct the bias-correction estimator.
-    
-    bws	
+
+    bws
     matrix containing the estimated bandwidths for each selected procedure.
-    
-    bwselect	
+
+    bwselect
     bandwidth selection procedure employed.
-    
-    kernel	
+
+    kernel
     kernel function used to construct the local-polynomial estimator(s).
-    
-    
+
+
     References
     ----------
     Calonico, S., M. D. Cattaneo, and M. H. Farrell. 2018. On the Effect of Bias Estimation on Coverage Accuracy in Nonparametric Inference. Journal of the American Statistical Association, 113(522): 767-779.
-    
+
     Calonico, S., M. D. Cattaneo, and M. H. Farrell. 2020. Optimal Bandwidth Choice for Robust Bias Corrected Inference in Regression Discontinuity Designs. Econometrics Journal, 23(2): 192-210.
-    
+
     Calonico, S., M. D. Cattaneo, M. H. Farrell, and R. Titiunik. 2017. rdrobust: Software for Regression Discontinuity Designs. Stata Journal 17(2): 372-404.
-    
+
     Calonico, S., M. D. Cattaneo, M. H. Farrell, and R. Titiunik. 2019. Regression Discontinuity Designs using Covariates. Review of Economics and Statistics, 101(3): 442-451.
-    
+
     Calonico, S., M. D. Cattaneo, and R. Titiunik. 2014a. Robust Nonparametric Confidence Intervals for Regression-Discontinuity Designs. Econometrica 82(6): 2295-2326.
-    
+
     Calonico, S., M. D. Cattaneo, and R. Titiunik. 2014b. Robust Data-Driven Inference in the Regression-Discontinuity Design. Stata Journal 14(4): 909-946.
-    
+
     Calonico, S., M. D. Cattaneo, and R. Titiunik. 2015a. Optimal Data-Driven Regression Discontinuity Plots. Journal of the American Statistical Association 110(512): 1753-1769.
-    
+
     Calonico, S., M. D. Cattaneo, and R. Titiunik. 2015b. rdrobust: An R Package for Robust Nonparametric Inference in Regression-Discontinuity Designs. R Journal 7(1): 38-51.
-    
+
     Cattaneo, M. D., B. Frandsen, and R. Titiunik. 2015. Randomization Inference in the Regression Discontinuity Design: An Application to the Study of Party Advantages in the U.S. Senate. Journal of Causal Inference 3(1): 1-24.
-    
+
     See Also
     rdrobust, rdplot
-    
+
     Example
     -------
     >>> x = numpy.random.uniform(low=-1, high=1, size=1000)
     >>> y = 5+3*x+2*(x>=0) + numpy.random.uniform(size = 1000)
     >>> rdbwselect(y,x)
-    '''
+    """
     
     if prchk:
         x = np.array(x).reshape(-1,1)

--- a/Python/rdrobust/src/rdrobust/rdplot.py
+++ b/Python/rdrobust/src/rdrobust/rdplot.py
@@ -689,8 +689,8 @@ def rdplot(y, x, c = 0, p = 4, nbins = None, binselect = "esmv", scale = None,
     rdplot_N_r    = aux_r['y']['count'].values
     rdplot_sd_y_r = aux_r['y']['std'].values
 		
-    rdplot_sd_y_l[np.isnan(rdplot_sd_y_l)] = 0
-    rdplot_sd_y_r[np.isnan(rdplot_sd_y_r)] = 0
+    rdplot_sd_y_l = np.nan_to_num(rdplot_sd_y_l)
+    rdplot_sd_y_r = np.nan_to_num(rdplot_sd_y_r)
     rdplot_sd_y = np.concatenate([rdplot_sd_y_l[::-1],rdplot_sd_y_r])
     rdplot_N = np.concatenate([rdplot_N_l[::-1],rdplot_N_r])
 	

--- a/Python/rdrobust/src/rdrobust/rdplot.py
+++ b/Python/rdrobust/src/rdrobust/rdplot.py
@@ -21,200 +21,200 @@ def rdplot(y, x, c = 0, p = 4, nbins = None, binselect = "esmv", scale = None,
                   hide = False, ci = None, shade = False, 
                   title = None, x_label = None, y_label = None, x_lim = None,
                   y_lim = None, col_dots = None, col_lines = None):
-    
-    '''
+
+    r"""
     Implements several data-driven Regression Discontinuity (RD) plots, using either evenly-spaced or quantile-spaced partitioning. Two type of RD plots are constructed: (i) RD plots with binned sample means tracing out the underlying regression function, and (ii) RD plots with binned sample means mimicking the underlying variability of the data. For technical and methodological details see Calonico, Cattaneo and Titiunik (2015a).
-    
+
     Companion commands are: rdrobust for point estimation and inference procedures, and rdbwselect for data-driven bandwidth selection.
-    
+
     A detailed introduction to this command is given in Calonico, Cattaneo and Titiunik (2015b) and Calonico, Cattaneo, Farrell and Titiunik (2017). A companion Stata package is described in Calonico, Cattaneo and Titiunik (2014).
-    
+
     For more details, and related Stata and R packages useful for analysis of RD designs, visit https://rdpackages.github.io/
-    
-    
+
+
     Parameters
     ----------
-    y	
+    y
     is the dependent variable.
-    
-    x	
+
+    x
     is the running variable (a.k.a. score or forcing variable).
-    
-    c	
+
+    c
     specifies the RD cutoff in x; default is c = 0.
-    
-    p	
+
+    p
     specifies the order of the global-polynomial used to approximate the population conditional mean functions for control and treated units; default is p = 4.
-    
-    nbins	
+
+    nbins
     specifies the number of bins used to the left of the cutoff, denoted J_-, and to the right of the cutoff, denoted J_+, respectively. If not specified, J_+ and J_- are estimated using the method and options chosen below.
-    
-    binselect	
+
+    binselect
     specifies the procedure to select the number of bins. This option is available only if J_- and J_+ are not set manually. Options are:
-    
+
     es: IMSE-optimal evenly-spaced method using spacings estimators.
-    
+
     espr: IMSE-optimal evenly-spaced method using polynomial regression.
-    
+
     esmv: mimicking variance evenly-spaced method using spacings estimators. This is the default option.
-    
+
     esmvpr: mimicking variance evenly-spaced method using polynomial regression.
-    
+
     qs: IMSE-optimal quantile-spaced method using spacings estimators.
-    
+
     qspr: IMSE-optimal quantile-spaced method using polynomial regression.
-    
+
     qsmv: mimicking variance quantile-spaced method using spacings estimators.
-    
+
     qsmvpr: mimicking variance quantile-spaced method using polynomial regression.
-    
-    scale	
+
+    scale
     specifies a multiplicative factor to be used with the optimal numbers of bins selected. Specifically, the number of bins used for the treatment and control groups will be scale\times \hat{J}_+ and scale\times \hat{J}_-, where \hat{J}_\cdot denotes the estimated optimal numbers of bins originally computed for each group; default is scale = 1.
-    
-    kernel	
+
+    kernel
     specifies the kernel function used to construct the local-polynomial estimator(s). Options are: triangular, epanechnikov, and uniform. Default is kernel=uniform (i.e., equal/no weighting to all observations on the support of the kernel).
-    
-    weights	
+
+    weights
     is the variable used for optional weighting of the estimation procedure. The unit-specific weights multiply the kernel function.
-    
-    h	
+
+    h
     specifies the bandwidth used to construct the (global) polynomial fits given the kernel choice kernel. If not specified, the bandwidths are chosen to span the full support of the data. If two bandwidths are specified, the first bandwidth is used for the data below the cutoff and the second bandwidth is used for the data above the cutoff.
-    
-    covs	
+
+    covs
     specifies additional covariates to be used in the polynomial regression.
-    
-    covs_eval	
+
+    covs_eval
     sets the evaluation points for the additional covariates, when included in the estimation. Options are: covs_eval = 0 (default) and covs_eval = "mean"
-    
-    covs_drop	
+
+    covs_drop
     if TRUE, it checks for collinear additional covariates and drops them. Default is TRUE.
-    
-    support	
+
+    support
     specifies an optional extended support of the running variable to be used in the construction of the bins; default is the sample range.
-    
-    subset	
+
+    subset
     an optional vector specifying a subset of observations to be used.
-    
-    masspoints	
+
+    masspoints
     checks and controls for repeated observations in the running variable. Options are:
-    
+
     (i) off: ignores the presence of mass points;
-    
+
     (ii) check: looks for and reports the number of unique observations at each side of the cutoff.
-    
+
     (iii) adjust: sets binselect() as polynomial regression when mass points are present.
-    
+
     Default option is masspoints=adjust.
-    
-    hide	
+
+    hide
     logical. If TRUE, it omits the RD plot; default is hide = FALSE.
-    
-    ci	
+
+    ci
     optional graphical option to display confidence intervals of selected level for each bin.
-    
-    shade	
+
+    shade
     optional graphical option to replace confidence intervals with shaded areas.
-    
-    title	
+
+    title
     optional title for the RD plot.
-    
-    x_label	
+
+    x_label
     optional label for the x-axis of the RD plot.
-    
-    y_label	
+
+    y_label
     optional label for the y-axis of the RD plot.
-    
-    x_lim	
+
+    x_lim
     optional setting for the range of the x-axis in the RD plot.
-    
-    y_lim	
+
+    y_lim
     optional setting for the range of the y-axis in the RD plot.
-    
-    col_dots	
+
+    col_dots
     optional setting for the color of the dots in the RD plot.
-    
-    col_lines	
+
+    col_lines
     optional setting for the color of the lines in the RD plot.
-    
+
     Returns
     -------
-    binselect	
+    binselect
     method used to compute the optimal number of bins.
-    
-    N	
+
+    N
     sample sizes used to the left and right of the cutoff.
-    
-    Nh	
+
+    Nh
     effective sample sizes used to the left and right of the cutoff.
-    
-    c	
+
+    c
     cutoff value.
-    
-    p	
+
+    p
     order of the global polynomial used.
-    
-    h	
+
+    h
     bandwidth used to the left and right of the cutoff.
-    
-    kernel	
+
+    kernel
     kernel used.
-    
-    J	
+
+    J
     selected number of bins to the left and right of the cutoff.
-    
-    J_IMSE	
+
+    J_IMSE
     IMSE optimal number of bins to the left and right of the cutoff.
-    
-    J_MV	
+
+    J_MV
     Mimicking variance number of bins to the left and right of the cutoff.
-    
-    coef	
+
+    coef
     matrix containing the coefficients of the p^{th} order global polynomial estimated both sides of the cutoff.
-    
-    scale	
+
+    scale
     selected scale value.
-    
-    rscale	
+
+    rscale
     implicit scale value.
-    
-    bin_avg	
+
+    bin_avg
     average bin length.
-    
-    bin_med	
+
+    bin_med
     median bin length.
-    
-    vars_bins	
+
+    vars_bins
     data frame containing the variables used to construct the bins: bin id, cutoff values, mean of x and y within each bin, cutoff points and confidence interval bounds.
-    
-    vars_poly	
+
+    vars_poly
     data frame containing the variables used to construct the global polynomial plot.
-    
-    rdplot	
+
+    rdplot
     a standard ggplot object that can be used for further customization.
-    
+
     References
     ----------
     Calonico, S., M. D. Cattaneo, M. H. Farrell, and R. Titiunik. 2017. rdrobust: Software for Regression Discontinuity Designs. Stata Journal 17(2): 372-404.
-    
+
     Calonico, S., M. D. Cattaneo, and R. Titiunik. 2014. Robust Data-Driven Inference in the Regression-Discontinuity Design. Stata Journal 14(4): 909-946.
-    
+
     Calonico, S., M. D. Cattaneo, and R. Titiunik. 2015a. Optimal Data-Driven Regression Discontinuity Plots. Journal of the American Statistical Association 110(512): 1753-1769.
-    
+
     Calonico, S., M. D. Cattaneo, and R. Titiunik. 2015b. rdrobust: An R Package for Robust Nonparametric Inference in Regression-Discontinuity Designs. R Journal 7(1): 38-51.
-    
+
     Cattaneo, M. D., B. Frandsen, and R. Titiunik. 2015. Randomization Inference in the Regression Discontinuity Design: An Application to the Study of Party Advantages in the U.S. Senate. Journal of Causal Inference 3(1): 1-24.
-    
+
     See Also
     --------
     rdbwselect, rdrobust
-    
-    
+
+
     Example
     -------
     >>> x = numpy.random.uniform(low=-1, high=1, size=1000)
     >>> y = 5+3*x+2*(x>=0) + numpy.random.uniform(size = 1000)
     >>> rdplot(y,x)
-    '''
+    """
     
     # Tidy the Input and remove NAN
     x = np.array(x).reshape(-1,1)

--- a/Python/rdrobust/src/rdrobust/rdrobust.py
+++ b/Python/rdrobust/src/rdrobust/rdrobust.py
@@ -21,216 +21,216 @@ def rdrobust(y, x, c = None, fuzzy = None, deriv = None,
              scalepar = 1, scaleregul = 1, sharpbw = False, 
              all = None, subset = None, masspoints = "adjust",
              bwcheck = None, bwrestrict = True, stdvars = False):
-    
-    '''
+
+    r"""
     Implements local polynomial Regression Discontinuity (RD) point estimators with robust bias-corrected confidence intervals and inference procedures developed in Calonico, Cattaneo and Titiunik (2014a), Calonico, Cattaneo and Farrell (2018), Calonico, Cattaneo, Farrell and Titiunik (2019), and Calonico, Cattaneo and Farrell (2020). It also computes alternative estimation and inference procedures available in the literature.
-   
+
     Parameters
     ----------
-    y: array	
+    y: array
     is the dependent variable.
-    
-    x	
+
+    x
     is the running variable (a.k.a. score or forcing variable).
-    
-    c	
+
+    c
     specifies the RD cutoff in x; default is c = 0.
-    
-    fuzzy	
+
+    fuzzy
     specifies the treatment status variable used to implement fuzzy RD estimation (or Fuzzy Kink RD if deriv=1 is also specified). Default is Sharp RD design and hence this option is not used.
-    
-    deriv	
+
+    deriv
     specifies the order of the derivative of the regression functions to be estimated. Default is deriv=0 (for Sharp RD, or for Fuzzy RD if fuzzy is also specified). Setting deriv=1 results in estimation of a Kink RD design (up to scale), or Fuzzy Kink RD if fuzzy is also specified.
-    
-    p	
+
+    p
     specifies the order of the local-polynomial used to construct the point-estimator; default is p = 1 (local linear regression).
-    
-    q	
+
+    q
     specifies the order of the local-polynomial used to construct the bias-correction; default is q = 2 (local quadratic regression).
-    
-    h	
+
+    h
     specifies the main bandwidth used to construct the RD point estimator. If not specified, bandwidth h is computed by the companion command rdbwselect. If two bandwidths are specified, the first bandwidth is used for the data below the cutoff and the second bandwidth is used for the data above the cutoff.
-    
-    b	
+
+    b
     specifies the bias bandwidth used to construct the bias-correction estimator. If not specified, bandwidth b is computed by the companion command rdbwselect. If two bandwidths are specified, the first bandwidth is used for the data below the cutoff and the second bandwidth is used for the data above the cutoff.
-    
-    rho	
+
+    rho
     specifies the value of rho, so that the bias bandwidth b equals h/rho. Default is rho = 1 if h is specified but b is not.
-    
-    covs	
+
+    covs
     specifies additional covariates to be used for estimation and inference.
-    
-    covs_drop	
+
+    covs_drop
     if TRUE, it checks for collinear additional covariates and drops them. Default is TRUE.
-    
-    kernel	
+
+    kernel
     is the kernel function used to construct the local-polynomial estimator(s). Options are triangular (default option), epanechnikov and uniform.
-    
-    weights	
+
+    weights
     is the variable used for optional weighting of the estimation procedure. The unit-specific weights multiply the kernel function.
-    
-    bwselect	
+
+    bwselect
     specifies the bandwidth selection procedure to be used. By default it computes both h and b, unless rho is specified, in which case it only computes h and sets b=h/rho.
-    
+
     Options are:
-    
+
     mserd one common MSE-optimal bandwidth selector for the RD treatment effect estimator.
-    
+
     msetwo two different MSE-optimal bandwidth selectors (below and above the cutoff) for the RD treatment effect estimator.
-    
+
     msesum one common MSE-optimal bandwidth selector for the sum of regression estimates (as opposed to difference thereof).
-    
+
     msecomb1 for min(mserd,msesum).
-    
+
     msecomb2 for median(msetwo,mserd,msesum), for each side of the cutoff separately.
-    
+
     cerrd one common CER-optimal bandwidth selector for the RD treatment effect estimator.
-    
+
     certwo two different CER-optimal bandwidth selectors (below and above the cutoff) for the RD treatment effect estimator.
-    
+
     cersum one common CER-optimal bandwidth selector for the sum of regression estimates (as opposed to difference thereof).
-    
+
     cercomb1 for min(cerrd,cersum).
-    
+
     cercomb2 for median(certwo,cerrd,cersum), for each side of the cutoff separately.
-    
+
     Note: MSE = Mean Square Error; CER = Coverage Error Rate. Default is bwselect=mserd. For details on implementation see Calonico, Cattaneo and Titiunik (2014a), Calonico, Cattaneo and Farrell (2018), and Calonico, Cattaneo, Farrell and Titiunik (2019), and the companion software articles.
-    
-    vce	
+
+    vce
     specifies the procedure used to compute the variance-covariance matrix estimator. Options are:
-    
+
     nn for heteroskedasticity-robust nearest neighbor variance estimator with nnmatch the (minimum) number of neighbors to be used.
-    
+
     hc0 for heteroskedasticity-robust plug-in residuals variance estimator without weights.
-    
+
     hc1 for heteroskedasticity-robust plug-in residuals variance estimator with hc1 weights.
-    
+
     hc2 for heteroskedasticity-robust plug-in residuals variance estimator with hc2 weights.
-    
+
     hc3 for heteroskedasticity-robust plug-in residuals variance estimator with hc3 weights.
-    
+
     Default is vce=nn.
-    
-    cluster	
+
+    cluster
     indicates the cluster ID variable used for cluster-robust variance estimation with degrees-of-freedom weights. By default it is combined with vce=nn for cluster-robust nearest neighbor variance estimation. Another option is plug-in residuals combined with vce=hc0.
-    
-    nnmatch	
+
+    nnmatch
     to be combined with for vce=nn for heteroskedasticity-robust nearest neighbor variance estimator with nnmatch indicating the minimum number of neighbors to be used. Default is nnmatch=3
-    
-    level	
+
+    level
     sets the confidence level for confidence intervals; default is level = 95.
-    
-    scalepar	
+
+    scalepar
     specifies scaling factor for RD parameter of interest. This option is useful when the population parameter of interest involves a known multiplicative factor (e.g., sharp kink RD). Default is scalepar = 1 (no scaling).
-    
-    scaleregul	
+
+    scaleregul
     specifies scaling factor for the regularization term added to the denominator of the bandwidth selectors. Setting scaleregul = 0 removes the regularization term from the bandwidth selectors; default is scaleregul = 1.
-    
-    sharpbw	
+
+    sharpbw
     option to perform fuzzy RD estimation using a bandwidth selection procedure for the sharp RD model. This option is automatically selected if there is perfect compliance at either side of the cutoff.
-    
-    all	
+
+    all
     if specified, rdrobust reports three different procedures:
-    
+
     (i) conventional RD estimates with conventional standard errors.
-    
+
     (ii) bias-corrected estimates with conventional standard errors.
-    
+
     (iii) bias-corrected estimates with robust standard errors.
-    
-    subset	
+
+    subset
     an optional vector specifying a subset of observations to be used.
-    
-    masspoints	
+
+    masspoints
     checks and controls for repeated observations in the running variable. Options are:
-    
+
     (i) off: ignores the presence of mass points;
-    
+
     (ii) check: looks for and reports the number of unique observations at each side of the cutoff.
-    
+
     (iii) adjust: controls that the preliminary bandwidths used in the calculations contain a minimal number of unique observations. By default it uses 10 observations, but it can be manually adjusted with the option bwcheck).
-    
+
     Default option is masspoints=adjust.
-    
-    bwcheck	
+
+    bwcheck
     if a positive integer is provided, the preliminary bandwidth used in the calculations is enlarged so that at least bwcheck unique observations are used.
-    
-    bwrestrict	
+
+    bwrestrict
     if TRUE, computed bandwidths are restricted to lie within the range of x; default is bwrestrict = TRUE.
-    
-    stdvars	
+
+    stdvars
     if TRUE, x and y are standardized before computing the bandwidths; default is stdvars = FALSE.
-    
+
     Returns
     -------
-    N	
+    N
     vector with the sample sizes used to the left and to the right of the cutoff.
-    
-    N_h	
+
+    N_h
     vector with the effective sample sizes used to the left and to the right of the cutoff.
-    
-    c	
+
+    c
     cutoff value.
-    
-    p	
+
+    p
     order of the polynomial used for estimation of the regression function.
-    
-    q	
+
+    q
     order of the polynomial used for estimation of the bias of the regression function.
-    
-    bws	
+
+    bws
     matrix containing the bandwidths used.
-    
-    tau_cl	
+
+    tau_cl
     conventional local-polynomial estimate to the left and to the right of the cutoff.
-    
-    tau_bc	
+
+    tau_bc
     bias-corrected local-polynomial estimate to the left and to the right of the cutoff.
-    
-    coef	
+
+    coef
     vector containing conventional and bias-corrected local-polynomial RD estimates.
-    
-    se	
+
+    se
     vector containing conventional and robust standard errors of the local-polynomial RD estimates.
-    
-    bias	
+
+    bias
     estimated bias for the local-polynomial RD estimator below and above the cutoff.
-    
-    beta_p_l	
+
+    beta_p_l
     conventional p-order local-polynomial estimates to the left of the cutoff.
-    
-    beta_p_r	
+
+    beta_p_r
     conventional p-order local-polynomial estimates to the right of the cutoff.
-    
-    V_cl_l	
+
+    V_cl_l
     conventional variance-covariance matrix estimated below the cutoff.
-    
-    V_cl_r	
+
+    V_cl_r
     conventional variance-covariance matrix estimated above the cutoff.
-    
-    V_rb_l	
+
+    V_rb_l
     robust variance-covariance matrix estimated below the cutoff.
-    
-    V_rb_r	
+
+    V_rb_r
     robust variance-covariance matrix estimated above the cutoff.
-    
-    pv	
+
+    pv
     vector containing the p-values associated with conventional, bias-corrected and robust local-polynomial RD estimates.
-    
-    ci	
+
+    ci
     matrix containing the confidence intervals associated with conventional, bias-corrected and robust local-polynomial RD estimates.
-    
-    
+
+
     See Also
     --------
     rdbwselect, rdplot
-    
+
     Example
-    ------- 
+    -------
     >>> x = numpy.random.uniform(low=-1, high=1, size=1000)
     >>> y = 5+3*x+2*(x>=0) + numpy.random.uniform(size = 1000)
     >>> rdrobust(y,x)
-    '''
+    """
     
     # Check for errors in the INPUT
     if p is None and deriv is not None: p = deriv + 1


### PR DESCRIPTION
The script below fails with `ValueError: assignment destination is read-only` when using `numpy>=2.0` because of this line: `rdplot_sd_y_l[np.isnan(rdplot_sd_y_l)] = 0`. This PR replaces this with `rdplot_sd_y_l = np.nan_to_num(rdplot_sd_y_l)` 
  
The second commit in the PR fixes the doctoring formatting to properly escape special characters (e.g. " \hat{J}") which raises avoidable warnings.

```python
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     "numpy>=2.0",
#     "rdrobust"
# ]
# ///
import numpy as np
from rdrobust import rdplot

rng = np.random.default_rng(42)
n = 500
x = rng.normal(size=n)
y = 3 + 2 * x + rng.normal(size=n)

rd = rdplot(y=y, x=x, c=0)
```